### PR TITLE
Resolve relative file errors

### DIFF
--- a/playing_cards/models.py
+++ b/playing_cards/models.py
@@ -20,11 +20,12 @@ from typing import Any, Literal
 
 Colour = Literal["black", "red"]
 
+HERE = pathlib.Path(__file__).parent
 SUITS: dict[str, dict[str, str]] = tomllib.loads(
-    pathlib.Path("playing_cards/suits.toml").read_text(encoding="utf-8")
+    (HERE / "suits.toml").read_text(encoding="utf-8")
 )
 RANKS: dict[str, dict[str, str]] = tomllib.loads(
-    pathlib.Path("playing_cards/ranks.toml").read_text(encoding="utf-8")
+    (HERE / "ranks.toml").read_text(encoding="utf-8")
 )
 
 


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Resolve relative file path errors by using the current file's directory as the base path for loading 'suits.toml' and 'ranks.toml'.

Bug Fixes:
- Fix relative file path errors by using the current file's directory as the base path for loading TOML files.

<!-- Generated by sourcery-ai[bot]: end summary -->